### PR TITLE
Fixed emojisplosion cancelling in home.page.ts

### DIFF
--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -8,7 +8,7 @@ import { emojisplosion, emojisplosions } from 'emojisplosion';
 })
 export class HomePage implements OnInit {
 
-  cancel: any;
+  cancel?: () => void;
 
   constructor() { }
 
@@ -45,6 +45,7 @@ export class HomePage implements OnInit {
         document.getElementById('demo').innerHTML = '&nbsp;&nbsp;&nbsp;EXPLODING NOW !!!';
         // Commence explosions!
         const { cancel } = emojisplosions();
+        this.cancel = cancel;
       }
     }, 1000);
 
@@ -54,7 +55,13 @@ export class HomePage implements OnInit {
     console.log('ionViewDidLeave home page');
 
     // ...but stop after two seconds.
-    setTimeout(this.cancel, 2000);
+    setTimeout(
+      () => {
+        if (this.cancel) {
+          this.cancel();
+        }
+      },
+      2000);
   }
 
 }


### PR DESCRIPTION
The code was never assigning `cancel` to anywhere, so `this.cancel` was always undefined. This sets `this.cancel`, then when the page leaves, if `this.cancel` was assigned to, it's called.